### PR TITLE
fix(kiwi-atoms): emit pageChanged on button click

### DIFF
--- a/packages/atoms/src/components/kiwi-pager/kiwi-pager.spec.tsx
+++ b/packages/atoms/src/components/kiwi-pager/kiwi-pager.spec.tsx
@@ -86,7 +86,7 @@ describe('kiwi-pager', () => {
     pager.rootInstance?.disconnectedCallback();
   });
 
-  it('emits pageChanged event after debounce', async () => {
+  it('emits pageChanged event on input after debounce', async () => {
     jest.useFakeTimers();
 
     const pager = await newSpecPage({
@@ -123,6 +123,45 @@ describe('kiwi-pager', () => {
 
       expect(pagerInst.pageChanged.emit).toBeCalledTimes(1);
       expect(pagerInst.pageChanged.emit).toBeCalledWith({ page: 2 });
+
+      pager.rootInstance?.disconnectedCallback();
+    })();
+
+    jest.useRealTimers();
+  });
+
+  it('emits pageChanged event on click after debounce', async () => {
+    jest.useFakeTimers();
+
+    const pager = await newSpecPage({
+      components: [KiwiPager],
+      template: () => (
+        <kiwi-pager
+          page={0}
+          total={3}
+          ofLabel="vong"
+          debounce={400}
+        ></kiwi-pager>
+      ),
+    });
+
+    fakeSchedulers((advance) => {
+      const pagerInst: KiwiPager = pager.rootInstance;
+
+      jest.spyOn(pagerInst.pageChanged, 'emit');
+
+      const nextButton = document.querySelector<HTMLButtonElement>(
+        '[aria-label="Next Page"]',
+      );
+
+      expectDefined(nextButton);
+
+      nextButton.click();
+
+      advance(400);
+
+      expect(pagerInst.pageChanged.emit).toBeCalledTimes(1);
+      expect(pagerInst.pageChanged.emit).toBeCalledWith({ page: 1 });
 
       pager.rootInstance?.disconnectedCallback();
     })();

--- a/packages/atoms/src/components/kiwi-pager/kiwi-pager.tsx
+++ b/packages/atoms/src/components/kiwi-pager/kiwi-pager.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
   State,
 } from '@stencil/core';
-import { concat, Subject } from 'rxjs';
+import { merge, Subject } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -65,7 +65,7 @@ export class KiwiPager implements ComponentInterface {
   private disconnect$: Subject<void> = new Subject();
 
   componentDidLoad(): void {
-    concat(
+    merge(
       this.inputChangedDebouncer.pipe(
         distinctUntilChanged(),
         debounceTime(this.debounce),


### PR DESCRIPTION
The pageChange event was not emitted due to the use
of rxjs concat which waits for the previous observable
to complete before the next subscription happens