### PR TITLE
prevent dropdown from sticking over right screen edge

### DIFF
--- a/packages/atoms/package-lock.json
+++ b/packages/atoms/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@kiwigrid/kiwi-atoms",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.6.0",

--- a/packages/atoms/src/components/kiwi-checkbox-dropdown-menu/kiwi-checkbox-dropdown-menu.stories.js
+++ b/packages/atoms/src/components/kiwi-checkbox-dropdown-menu/kiwi-checkbox-dropdown-menu.stories.js
@@ -34,8 +34,8 @@ export const rightScreenEdge = (args) => {
   const { buttonText, options, menuEntryWidth } = args;
 
   return html`<div class="panel panel-default m-1">
-    <div class="panel-body" style="text-align:right">
-      <kiwi-checkbox-dropdown-menu>
+    <div class="panel-body">
+      <kiwi-checkbox-dropdown-menu class="pull-right">
         <div slot="dropdown-toggle">${buttonText}</div>
         <kiwi-checkbox-menu slot="dropdown-content">
           ${options.map(

--- a/packages/atoms/src/components/kiwi-checkbox-dropdown-menu/kiwi-checkbox-dropdown-menu.stories.js
+++ b/packages/atoms/src/components/kiwi-checkbox-dropdown-menu/kiwi-checkbox-dropdown-menu.stories.js
@@ -29,3 +29,31 @@ basic.args = {
   buttonText: 'Click me',
   options: ['Option 1', 'Option 2', 'Option 3'],
 };
+
+export const rightScreenEdge = (args) => {
+  const { buttonText, options, menuEntryWidth } = args;
+
+  return html`<div class="panel panel-default m-1">
+    <div class="panel-body" style="text-align:right">
+      <kiwi-checkbox-dropdown-menu>
+        <div slot="dropdown-toggle">${buttonText}</div>
+        <kiwi-checkbox-menu slot="dropdown-content">
+          ${options.map(
+            (o) => html`<kiwi-checkbox-menu-item>
+              <kiwi-labeled-checkbox>
+                <div style="min-width:${menuEntryWidth}">
+                  ${o}
+                </div></kiwi-labeled-checkbox
+              >
+            </kiwi-checkbox-menu-item>`,
+          )}
+        </kiwi-checkbox-menu>
+      </kiwi-checkbox-dropdown-menu>
+    </div>
+  </div>`;
+};
+rightScreenEdge.args = {
+  buttonText: 'Click me',
+  options: ['Very Long Option 1', 'Very Long Option 2', 'Very Long Option 3'],
+  menuEntryWidth: ['120px'],
+};

--- a/packages/atoms/src/components/kiwi-dropdown/kiwi-dropdown.tsx
+++ b/packages/atoms/src/components/kiwi-dropdown/kiwi-dropdown.tsx
@@ -1,6 +1,7 @@
 import {
   Component,
   ComponentInterface,
+  Element,
   Event,
   EventEmitter,
   h,
@@ -15,6 +16,9 @@ import {
   shadow: false,
 })
 export class KiwiDropdown implements ComponentInterface {
+  @Element()
+  el: HTMLElement | undefined;
+
   /**
    * Css class to be applied to container.
    */
@@ -71,6 +75,29 @@ export class KiwiDropdown implements ComponentInterface {
   };
   private handleMenuEnter: () => void = () => (this.hover = true);
   private handleMenuLeave: () => void = () => (this.hover = false);
+
+  componentDidRender(): void {
+    // make sure that the dropdown does not stick over the right edge of the body
+    if(this.el) {
+      const dropdown = this.el.querySelector('.dropdown-menu') as HTMLElement;
+      if (this.open) {
+        const ddBoundingRect = dropdown.getBoundingClientRect();
+        let offset = Math.ceil(
+          ddBoundingRect.right - window.visualViewport.width,
+        );
+
+        if (offset > 0) {
+          // if the popup is wider than the screen then make it start at the left screen edge
+          if (ddBoundingRect.left - offset < 0) {
+            offset = ddBoundingRect.left;
+          }
+          dropdown.style.translate = `-${Math.ceil(offset)}px`;
+        }
+      } else {
+        dropdown.style.translate = '0px';
+      }
+    }
+  }
 
   private set open(isOpen: boolean) {
     this._open = isOpen;

--- a/packages/atoms/src/components/kiwi-dropdown/kiwi-dropdown.tsx
+++ b/packages/atoms/src/components/kiwi-dropdown/kiwi-dropdown.tsx
@@ -1,7 +1,6 @@
 import {
   Component,
   ComponentInterface,
-  Element,
   Event,
   EventEmitter,
   h,
@@ -16,8 +15,7 @@ import {
   shadow: false,
 })
 export class KiwiDropdown implements ComponentInterface {
-  @Element()
-  el: HTMLElement | undefined;
+  private dropdownEl: HTMLDivElement | undefined;
 
   /**
    * Css class to be applied to container.
@@ -63,7 +61,10 @@ export class KiwiDropdown implements ComponentInterface {
         >
           <slot name="dropdown-toggle" />
         </button>
-        <div class="dropdown-menu">
+        <div
+          class="dropdown-menu"
+          ref={(el) => (this.dropdownEl = el as HTMLInputElement)}
+        >
           <slot name="dropdown-content" />
         </div>
       </div>
@@ -78,23 +79,23 @@ export class KiwiDropdown implements ComponentInterface {
 
   componentDidRender(): void {
     // make sure that the dropdown does not stick over the right edge of the body
-    if(this.el) {
-      const dropdown = this.el.querySelector('.dropdown-menu') as HTMLElement;
+    this.adjustPositionAtScreenEdge();
+  }
+
+  private adjustPositionAtScreenEdge(): void {
+    if (this.dropdownEl) {
       if (this.open) {
-        const ddBoundingRect = dropdown.getBoundingClientRect();
-        let offset = Math.ceil(
-          ddBoundingRect.right - window.visualViewport.width,
-        );
+        const rect = this.dropdownEl.getBoundingClientRect();
+        const offset =
+          rect.width > window.visualViewport.width
+            ? Math.floor(rect.left)
+            : Math.ceil(rect.right - window.visualViewport.width);
 
         if (offset > 0) {
-          // if the popup is wider than the screen then make it start at the left screen edge
-          if (ddBoundingRect.left - offset < 0) {
-            offset = ddBoundingRect.left;
-          }
-          dropdown.style.translate = `-${Math.ceil(offset)}px`;
+          this.dropdownEl.style.translate = `-${Math.ceil(offset)}px`;
         }
       } else {
-        dropdown.style.translate = '0px';
+        this.dropdownEl.style.translate = '0px';
       }
     }
   }


### PR DESCRIPTION
Support situations where the dropdown menu sticks to the screen edge:
In these situation the dropdown is now shifted to the left somewhat so that it ends at the right screen edge without causing horizontal scrolling